### PR TITLE
Associations, Delete, and Close

### DIFF
--- a/api/polls.js
+++ b/api/polls.js
@@ -344,6 +344,39 @@ router.patch("/:userId/edit/:id", authenticateJWT, async (req, res) => {
   }
 });
 
+// Close a poll
+router.patch("/:userId/close/:id", async (req, res) => {
+  const userId = Number(req.params.userId);
+  const pollId = Number(req.params.id);
+
+  try {
+    const rawPoll = await Poll.findByPk(pollId);
+    if (!rawPoll)
+      return res.status(404).send({ 
+        error: `Error closing poll: Poll with ID ${pollId} not found`
+      });
+    
+    const poll = rawPoll.toJSON();
+    if (poll.creatorId !== userId)
+      return res.status(403).send({ 
+        error: `Error closing poll: You are not the owner of the poll with ID ${pollId}`
+      });
+    
+    if (poll.status !== "Open")
+      return res.status(403).send({ 
+        error: `Error closing poll: Cannot close poll with ID ${pollId} because it is not open`
+      });
+
+    await rawPoll.update({
+      status: "Closed",
+    });
+    res.status(200).send({ message: `Successfully closed poll with ID ${pollId}` });
+  } catch (error) {
+    console.error(error);
+    res.status(500).send({ error: `Error closing poll with ID ${pollId}: ${error}` });
+  }
+});
+
 // Delete a draft poll
 router.delete("/:userId/delete/:id", async (req, res) => {
   try {

--- a/api/polls.js
+++ b/api/polls.js
@@ -132,9 +132,6 @@ router.get("/mypolls", async (req, res) => {
       where: { creatorId: userId },
     });
 
-    console.log("CAPCAP")
-    console.log(result);
-
     res.send(result);
   } catch (error) {
     res.status(501).send("Not Implemented");
@@ -344,6 +341,38 @@ router.patch("/:userId/edit/:id", authenticateJWT, async (req, res) => {
     res.status(200).send({ message: "Succesfully updated poll" });
   } catch (error) {
     res.status(500).send({ error: `Error updating poll: ${error}` });
+  }
+});
+
+// Delete a draft poll
+router.delete("/:userId/delete/:id", async (req, res) => {
+  try {
+    const userId = Number(req.params.userId);
+    const pollId = Number(req.params.id);
+
+    const rawPoll = await Poll.findByPk(pollId);
+    if (!rawPoll)
+      return res.status(404).send({ 
+        error: `Error deleting draft: Poll with ID ${pollId} not found`
+      });
+  
+    const poll = rawPoll.toJSON();
+    console.log(`USER: ${userId} | POLL:`, poll);
+    if (poll.creatorId !== userId)
+      return res.status(403).send({ 
+        error: `Error deleting draft: You are not the owner of the poll with ID ${pollId}`
+      });
+    
+    if (poll.status !== "Draft")
+      return res.status(403).send({ 
+        error: `Error deleting draft: Cannot delete poll with ID ${pollId} because it is not a draft`
+      });
+
+    await rawPoll.destroy();
+    res.status(200).send({ message: `Successfully deleted poll with ID ${pollId}` });
+  } catch (error) {
+    console.error(error);
+    res.status(500).send({ error: `Error deleting draft: ${error}` });
   }
 });
 

--- a/api/polls.js
+++ b/api/polls.js
@@ -345,7 +345,7 @@ router.patch("/:userId/edit/:id", authenticateJWT, async (req, res) => {
 });
 
 // Close a poll
-router.patch("/:userId/close/:id", async (req, res) => {
+router.patch("/:userId/close/:id", authenticateJWT, async (req, res) => {
   const userId = Number(req.params.userId);
   const pollId = Number(req.params.id);
 
@@ -378,7 +378,7 @@ router.patch("/:userId/close/:id", async (req, res) => {
 });
 
 // Delete a draft poll
-router.delete("/:userId/delete/:id", async (req, res) => {
+router.delete("/:userId/delete/:id", authenticateJWT, async (req, res) => {
   try {
     const userId = Number(req.params.userId);
     const pollId = Number(req.params.id);
@@ -390,7 +390,6 @@ router.delete("/:userId/delete/:id", async (req, res) => {
       });
   
     const poll = rawPoll.toJSON();
-    console.log(`USER: ${userId} | POLL:`, poll);
     if (poll.creatorId !== userId)
       return res.status(403).send({ 
         error: `Error deleting draft: You are not the owner of the poll with ID ${pollId}`

--- a/database/index.js
+++ b/database/index.js
@@ -6,91 +6,91 @@ const PollVote = require("./poll_vote");
 const PollResult = require("./poll_result");
 
 // Create one to many relationship between User and Poll
-Poll.belongsTo(User, {
-  as: "creator",
+User.hasMany(Poll, {
   foreignKey: {
     name: "creatorId",
     allowNull: false,
   },
-});
-User.hasMany(Poll, {
-  foreignKey: "creatorId",
   onDelete: "CASCADE",
   onUpdate: "CASCADE",
   as: "polls",
 });
+Poll.belongsTo(User, {
+  as: "creator",
+  foreignKey: "creatorId",
+});
 
 // Create one to many relationship between Poll and PollOption
-PollOption.belongsTo(Poll, {
+Poll.hasMany(PollOption, {
   foreignKey: {
     name: "pollId",
     allowNull: false,
   },
-});
-Poll.hasMany(PollOption, {
-  foreignKey: "pollId",
   onDelete: "CASCADE",
   onUpdate: "CASCADE",
 });
+PollOption.belongsTo(Poll, {
+  foreignKey: "pollId",
+});
 
 // Create (zero or one) to many relationship between User and PollVote
-PollVote.belongsTo(User, {
-  as: "voter",
+User.hasMany(PollVote, {
   foreignKey: {
     name: "userId",
     allowNull: true,
   },
-});
-User.hasMany(PollVote, {
-  foreignKey: "userId",
   onDelete: "SET NULL",
   onUpdate: "CASCADE",
 });
+PollVote.belongsTo(User, {
+  as: "voter",
+  foreignKey: "userId",
+});
 
 // Create one to many relationship between PollOption and PollVote
-PollVote.belongsTo(PollOption, {
+PollOption.hasMany(PollVote, {
   foreignKey: {
     name: "optionId",
     allowNull: false,
   },
-});
-PollOption.hasMany(PollVote, {
-  foreignKey: "optionId",
   onDelete: "CASCADE",
   onUpdate: "CASCADE",
 });
+PollVote.belongsTo(PollOption, {
+  foreignKey: "optionId",
+});
 
 // Create a one to many relationship between Poll and PollVote
-PollVote.belongsTo(Poll, {
+Poll.hasMany(PollVote, {
   foreignKey: {
     name: "pollId",
     allowNull: false,
   },
-});
-Poll.hasMany(PollVote, {
-  foreignKey: "pollId",
   onDelete: "CASCADE",
   onUpdate: "CASCADE",
 });
-
-// Create a one to many relationship between Poll and PollResult
-PollResult.belongsTo(Poll, {
+PollVote.belongsTo(Poll, {
   foreignKey: "pollId",
 });
+
+// Create a one to many relationship between Poll and PollResult
 Poll.hasMany(PollResult, {
   foreignKey: "pollId",
   onDelete: "CASCADE",
   onUpdate: "CASCADE",
 });
+PollResult.belongsTo(Poll, {
+  foreignKey: "pollId",
+});
 
 // Create a one to many relationship between PollOption and PollResult
-PollResult.belongsTo(PollOption, {
-  foreignKey: "optionId",
-});
 PollOption.hasMany(PollResult, {
   foreignKey: "optionId",
   onDelete: "CASCADE",
   onUpdate: "CASCADE",
+});
+PollResult.belongsTo(PollOption, {
+  foreignKey: "optionId",
 });
 
 module.exports = {

--- a/database/seed.js
+++ b/database/seed.js
@@ -410,7 +410,7 @@ const seed = async () => {
       {
         title: "What to eat",
         description: "Help us decided what to get for dinner!",
-        status: "Closed",
+        status: "Open",
         close_date: null,
         creatorId: 2,
       },


### PR DESCRIPTION
This PR adds 2 routes with JWT authentication:
- DELETE for deleting a draft polls
  - Returns a 404 Error if the poll is not found
  - Returns a 403 Error if the user is not the creator or the poll is not a draft
  - Returns a 500 Error for any other errors
  - Otherwise deletes the poll from the database and returns 200
- PATCH for closing an open poll
  - Returns a 404 Error if the poll is not found
  - Returns a 403 Error if the user is not the creator or the poll is not open
  - Returns a 500 Error for any other errors
  - Otherwise updates the poll's status to "Closed"

Associations were also reordered to fix a bug with handling foreign key constraints on delete and update

Closes #13 